### PR TITLE
Add announcements box in the compose area

### DIFF
--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import Immutable from 'immutable';
+import { Link } from 'react-router-dom';
+import axios from 'axios';
+
+class Announcement extends React.PureComponent {
+
+  static propTypes = {
+    item: ImmutablePropTypes.map,
+  }
+
+  render() {
+    const { item } = this.props;
+
+    const contents = [];
+    contents.push(<div key='body' className='announcements__body'>{item.get('body')}</div>);
+    if (item.get('icon')) {
+      const iconStyle = {
+        height: '40px',
+        width: '40px',
+        float: 'right',
+        backgroundImage: `url(${item.get('icon')})`,
+        backgroundSize: 'contain',
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat',
+        flex: '0 0 auto',
+      };
+      contents.push(<div key='icon' className='announcements__icon' style={iconStyle} />);
+    }
+
+    const href = item.get('href');
+
+    const style = {
+      display: 'flex',
+      padding: '10px',
+      margin: '10px',
+      backgroundColor: 'white',
+      color: '#313543',
+      boxShadow: '0 0 15px rgba(0,0,0,.2)',
+      borderRadius: '4px',
+      cursor: href ? 'pointer' : null,
+      textDecoration: 'none',
+    };
+
+    if (!href) {
+      return (<div className='announcements__item' style={style}>{contents}</div>);
+    } else if (href.startsWith('/web/')) {
+      return (<Link to={item.get('href').slice(4)} className='announcements__item' style={style}>{contents}</Link>);
+    } else {
+      return (<a href={item.get('href')} target='_blank' className='announcements__item' style={style}>{contents}</a>);
+    }
+  }
+
+}
+
+export default class Announcements extends React.PureComponent {
+
+  state = {
+    items: Immutable.Map(),
+  }
+
+  constructor () {
+    super();
+    this.refresh();
+  }
+
+  setPolling = () => {
+    this.timer = setTimeout(this.refresh, 60 * 1000);
+  }
+
+  cancelPolling = () => {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  refresh = () => {
+    this.timer = null;
+    axios.get('/system/announcements.json')
+    .then(resp => this.setState({ items: Immutable.fromJS(resp.data) }), () => {})
+    .then(this.setPolling);
+  }
+
+  render() {
+    const { items } = this.state;
+
+    return (
+      <ul className='announcements'>
+        {items.entrySeq().map(([key, item]) =>
+          <li key={key}>
+            <Announcement item={item} />
+          </li>
+        )}
+      </ul>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -11,6 +11,7 @@ import SearchContainer from './containers/search_container';
 import Motion from 'react-motion/lib/Motion';
 import spring from 'react-motion/lib/spring';
 import SearchResultsContainer from './containers/search_results_container';
+import Announcements from './components/announcements';
 
 const messages = defineMessages({
   start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
@@ -85,6 +86,7 @@ export default class Compose extends React.PureComponent {
           <div className='drawer__inner'>
             <NavigationContainer />
             <ComposeFormContainer />
+            <Announcements />
           </div>
 
           <Motion defaultStyle={{ x: -100 }} style={{ x: spring(showSearch ? 0 : -100, { stiffness: 210, damping: 20 }) }}>


### PR DESCRIPTION
/system/announcements.json:

```json
{
  "C++": {
    "body": "/web/ で始めると WebUI 内のリンク",
    "icon": "https://example.com/some/icon.jpg",
    "href": "/web/accounts/1"
  },
  "D": {
    "body": "それ以外は target=_blank で開く",
    "href": "https://example.com/"
  },
  "Erlang": {
    "body": "icon も href も省略可",
  }
}
```

ちなみに `/system/` に置いたのは upstream の `docker-compose.yml` でホストからマウントされているディレクトリだからです。スタイルは `custom.scss` あたりに追い出してもいいですね。