### PR TITLE
公式対応のメディアプロキシを使うように。

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import IconButton from './icon_button';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { isIOS } from '../is_mobile';
-import { remote_type, remote_url } from '../remote_media_detector';
+import { remote_type } from '../remote_media_detector';
 
 const messages = defineMessages({
   toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: 'Toggle visibility' },
@@ -154,16 +154,19 @@ class Item extends React.PureComponent {
         </div>
       );
     } else if (remote_type(attachment) === 'image') {
-      const sizes = `(min-width: 1025px) ${320 * (width / 100)}px, ${width}vw`;
+      const previewUrl = attachment.get('preview_url');
+
+      const originalUrl = attachment.get('url');
+
       thumbnail = (
         <a
           className='media-gallery__item-thumbnail'
-          href={remote_url(attachment)}
+          href={attachment.get('remote_url') || originalUrl}
           onClick={this.handleClick}
           target='_blank'
         >
-          <img src={attachment.get('remote_url')} sizes={sizes} alt='' />  
-      </a>
+          <img src={previewUrl} alt='' />
+        </a>
       );
     }
 

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -10,7 +10,7 @@ import StatusActionBar from './status_action_bar';
 import { FormattedMessage } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { MediaGallery, Video } from '../features/ui/util/async-components';
-import { remote_type, remote_url, remote_preview_url } from '../remote_media_detector';
+import { remote_type } from '../remote_media_detector';
 
 // We use the component (and not the container) since we do not want
 // to use the progress bar to show download progress
@@ -137,8 +137,8 @@ export default class Status extends ImmutablePureComponent {
         media = (
           <Bundle fetchComponent={Video} loading={this.renderLoadingVideoPlayer} >
             {Component => <Component
-              preview={remote_preview_url(video)}
-              src={remote_url(video)}
+              preview={video.get('preview_url')}
+              src={video.get('url')}
               width={239}
               height={110}
               sensitive={status.get('sensitive')}

--- a/app/javascript/mastodon/components/video_player.js
+++ b/app/javascript/mastodon/components/video_player.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import IconButton from './icon_button';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { isIOS } from '../is_mobile';
-import { remote_type, remote_url, remote_preview_url } from '../remote_media_detector';
 
 const messages = defineMessages({
   toggle_sound: { id: 'video_player.toggle_sound', defaultMessage: 'Toggle sound' },
@@ -166,7 +165,7 @@ export default class VideoPlayer extends React.PureComponent {
 
     if (this.state.preview && !autoplay) {
       return (
-        <button className='media-spoiler-video' style={{ width: `${width}px`, height: `${height}px`, backgroundImage: `url(${remote_preview_url(media)})` }} onClick={this.handleOpen}>
+        <button className='media-spoiler-video' style={{ width: `${width}px`, height: `${height}px`, backgroundImage: `url(${media.get('preview_url')})` }} onClick={this.handleOpen}>
           {spoilerButton}
           <div className='media-spoiler-video-play-icon'><i className='fa fa-play' /></div>
         </button>
@@ -192,7 +191,7 @@ export default class VideoPlayer extends React.PureComponent {
           role='button'
           tabIndex='0'
           ref={this.setRef}
-          src={remote_url(media)}
+          src={media.get('url')}
           autoPlay={!isIOS()}
           loop
           muted={this.state.muted}

--- a/app/javascript/mastodon/features/account_gallery/components/media_item.js
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import Permalink from '../../../components/permalink';
-import { remote_preview_url } from '../../../remote_media_detector';
 
 export default class MediaItem extends ImmutablePureComponent {
 
@@ -20,7 +19,7 @@ export default class MediaItem extends ImmutablePureComponent {
       content = <span className='media-gallery__gifv__label'>GIF</span>;
     }
 
-    style = { backgroundImage: `url(${remote_preview_url(media)})` };
+    style = { backgroundImage: `url(${media.get('preview_url')})` };
 
     return (
       <div className='account-gallery__item'>

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -11,7 +11,7 @@ import { FormattedDate, FormattedNumber } from 'react-intl';
 import CardContainer from '../containers/card_container';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import Video from '../../video';
-import { remote_type, remote_url, remote_preview_url } from '../../../remote_media_detector';
+import { remote_type } from '../../../remote_media_detector';
 
 export default class DetailedStatus extends ImmutablePureComponent {
 
@@ -53,8 +53,8 @@ export default class DetailedStatus extends ImmutablePureComponent {
 
         media = (
           <Video
-            preview={remote_preview_url(video)}
-            src={remote_url(video)}
+            preview={video.get('preview_url')}
+            src={video.get('url')}
             width={300}
             height={150}
             onOpenVideo={this.handleOpenVideo}

--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -7,7 +7,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 import IconButton from '../../../components/icon_button';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import ImageLoader from './image_loader';
-import { remote_type, remote_url, remote_image } from '../../../remote_media_detector';
+import { remote_type, attr_image } from '../../../remote_media_detector';
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },
@@ -73,15 +73,15 @@ export default class MediaModal extends ImmutablePureComponent {
     const rightNav = media.size > 1 && <button tabIndex='0' className='modal-container__nav  modal-container__nav--right' onClick={this.handleNextClick} aria-label={intl.formatMessage(messages.next)}><i className='fa fa-fw fa-chevron-right' /></button>;
 
     const content = media.map((image) => {
-      const width  = image.getIn(['meta', 'original', 'width']) || null;
-      const height = image.getIn(['meta', 'original', 'height']) || null;
+      const width  = image.getIn(['meta', 'original', 'width']) || attr_image(image).naturalWidth;
+      const height = image.getIn(['meta', 'original', 'height']) || attr_image(image).naturalHeight;
 
       if (image.get('type') === 'image') {
         return <ImageLoader previewSrc={image.get('preview_url')} src={image.get('url')} width={width} height={height} key={image.get('preview_url')} />;
       } else if (image.get('type') === 'gifv') {
         return <ExtendedVideoPlayer src={image.get('url')} muted controls={false} width={width} height={height} key={image.get('preview_url')} />;
       } else if (remote_type(image) === 'image') {
-        return <ImageLoader previewSrc={remote_url(image)} src={remote_url(image)} width={remote_image(image).naturalWidth} height={remote_image(image).naturalHeight} key={remote_url(image)} />;
+        return <ImageLoader previewSrc={image.get('preview_url')} src={image.get('url')} width={width} height={height} key={image.get('preview_url')} />;
       }
 
       return null;

--- a/app/javascript/mastodon/features/ui/components/video_modal.js
+++ b/app/javascript/mastodon/features/ui/components/video_modal.js
@@ -3,7 +3,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
 import Video from '../../video';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { remote_type, remote_url, remote_preview_url } from '../../../remote_media_detector';
 
 export default class VideoModal extends ImmutablePureComponent {
 
@@ -20,8 +19,8 @@ export default class VideoModal extends ImmutablePureComponent {
       <div className='modal-root__modal media-modal'>
         <div>
           <Video
-            preview={remote_preview_url(media)}
-            src={remote_url(media)}
+            preview={media.get('preview_url')}
+            src={media.get('url')}
             startTime={time}
             onCloseVideo={onClose}
           />

--- a/app/javascript/mastodon/remote_media_detector.js
+++ b/app/javascript/mastodon/remote_media_detector.js
@@ -15,28 +15,8 @@ export function remote_type(item) {
     return item.get('type');
 };
 
-export function remote_url(item) {
-    let remote_url = item.get('remote_url');
-    if (item.get('type') === 'unknown' && remote_url) {
-        return remote_url;
-    } else {
-        return item.get('url');
-    }
-};
-
-export function remote_preview_url(item) {
-    let remote_url = item.get('remote_url');
-    if (item.get('type') === 'unknown' && remote_url) {
-        return remote_url;
-    } else if (remote_type(item) === 'video') {
-        return null;
-    } else {
-        return item.get('preview_url');
-    }
-};
-
-export function remote_image(item) {
+export function attr_image(item) {
     let image = new Image();
-    image.src = item.get('remote_url');
+    image.src = item.get('url');
     return image;
 };


### PR DESCRIPTION
　機能は、以下の２点になります。
１．remove_remoteでは、unknownにならなくなりましたが、既存のunknownを戻すには一度media_proxyでアクセスする必要があります。unknownではその初めに1回のアクセスが発生しない可能性があるのでしばらくは入れておくといいと思います。
２．1.2.x時代の自鯖の画像がモーダルで見れない問題も対応します。
（タイムラインで1.2.xの画像が見れない件については、本家にマージされました。）