### PR TITLE
Make Announcements Great Again

### DIFF
--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -79,7 +79,7 @@ export default class Announcements extends React.PureComponent {
       },
     })
     .then(resp => (Announcement.isCacheControlled = !!resp.headers['cache-control'], resp))
-    .then(resp => this.setState({ items: Immutable.fromJS(resp.data) }), () => {})
+    .then(resp => this.setState({ items: Immutable.fromJS(resp.data) || {} }), () => {})
     .then(this.setPolling);
   }
 

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -19,3 +19,5 @@
 @import 'tables';
 @import 'admin';
 @import 'rtl';
+
+@import 'mods/announcements.scss'

--- a/app/javascript/styles/mods/announcements.scss
+++ b/app/javascript/styles/mods/announcements.scss
@@ -1,11 +1,9 @@
-@import 'application';
-
 .announcements__item {
   display: flex;
   padding: 10px;
   margin: 10px;
-  background-color: white;
-  color: #313543;
+  background: $primary-text-color;
+  color: $ui-base-color;
   box-shadow: 0 0 15px rgba(0,0,0,.2);
   border-radius: 4px;
   text-decoration: none;


### PR DESCRIPTION
テーマ機能との兼ね合いを考えた結果、アナウンス部分もテーマの一部、もしくは `variables.scss` の影響を受けるべきということで、`application.scss` 配下に置くことにしました。`variables.scss` で配色いじるだけのテーマならそのまま使えたらいいなという思いを込めて、色の指定方法も変えています。