### PR TITLE
Add blur to NSFW media in Account-gallery.

### DIFF
--- a/app/javascript/mastodon/features/account_gallery/components/media_item.js
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.js
@@ -21,6 +21,8 @@ export default class MediaItem extends ImmutablePureComponent {
 
     if (!status.get('sensitive')) {
       style = { backgroundImage: `url(${media.get('preview_url')})` };
+    } else {
+      style = { backgroundImage: `url(${media.get('preview_url')})` ,filter: `blur(4px)` };
     }
 
     return (

--- a/app/javascript/mastodon/features/account_gallery/components/media_item.js
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.js
@@ -19,7 +19,9 @@ export default class MediaItem extends ImmutablePureComponent {
       content = <span className='media-gallery__gifv__label'>GIF</span>;
     }
 
-    style = { backgroundImage: `url(${media.get('preview_url')})` };
+    if (!status.get('sensitive')) {
+      style = { backgroundImage: `url(${media.get('preview_url')})` };
+    }
 
     return (
       <div className='account-gallery__item'>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4104,6 +4104,7 @@ button.icon-button.active i.fa-retweet {
   width: calc(100% / 3 - 4px);
   height: 95px;
   margin: 2px;
+  overflow: hidden;
 
   a {
     display: block;


### PR DESCRIPTION
プロフィールページのメディア一覧上の、NSFWが付いた画像にぼかしをかけるようにします。

![example](https://user-images.githubusercontent.com/31636248/32497438-ee0d9ae8-c40f-11e7-95c5-80b5c8ac4d40.PNG)
