### PR TITLE
Announcements改修

### DIFF
--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -71,6 +71,15 @@ export default class Announcements extends React.PureComponent {
       this.timer = null;
     }
   }
+  
+  deleteServiceWorkerCache = () => {
+    // files in /system/ will be cached by SW
+    if (self.caches) {
+      return caches.open('mastodon-system')
+        .then(cache => cache.delete(window.origin + '/system/announcements.json'))
+        .catch(() => {});
+    }
+  }
 
   refresh = () => {
     this.timer = null;
@@ -87,6 +96,7 @@ export default class Announcements extends React.PureComponent {
     })
     .then(resp => this.setState({ items: Announcement.cache = Immutable.fromJS(resp.data) || {} }))
     .catch(err => err.response.status !== 304 && console.warn(err))
+    .then(this.deleteServiceWorkerCache)
     .then(this.setPolling);
   }
 


### PR DESCRIPTION
* lintのwarning対応
* クラス名の間違いの修正 (fixes #18)
* 2.4でServiceWorkerにキャッシュされてしまう件の修正
  これに関しては a) /system/外に移動する b) キャッシュを消す の二つの案があり、このPRでは後者を採用しました=運用方法に変化はありません。