### PR TITLE
Fix announcements background color definition.

### DIFF
--- a/app/javascript/styles/mods/announcements.scss
+++ b/app/javascript/styles/mods/announcements.scss
@@ -2,8 +2,8 @@
   display: flex;
   padding: 10px;
   margin: 10px;
-  background: $primary-text-color;
-  color: $ui-base-color;
+  background: $simple-background-color;
+  color: $inverted-text-color;
   box-shadow: 0 0 15px rgba(0,0,0,.2);
   border-radius: 4px;
   text-decoration: none;


### PR DESCRIPTION
サイトテーマ「 Mastodon (ライト) 」での announcements 欄の色を自然な色に変更します。
普段のテーマでも自然な色で表現できます。
<img width="296" alt="2018-08-16 22 16 57" src="https://user-images.githubusercontent.com/766076/44212994-be5a4f00-a1a7-11e8-8754-2395c783dec8.png">
<img width="295" alt="2018-08-16 22 56 57" src="https://user-images.githubusercontent.com/766076/44213007-c4e8c680-a1a7-11e8-83b9-a71029f0d0c2.png">
