### PR TITLE
シングルカラムレイアウトへの Announcements 追加

### DIFF
--- a/app/javascript/mastodon/features/ui/components/compose_panel.js
+++ b/app/javascript/mastodon/features/ui/components/compose_panel.js
@@ -2,6 +2,7 @@ import React from 'react';
 import SearchContainer from 'mastodon/features/compose/containers/search_container';
 import ComposeFormContainer from 'mastodon/features/compose/containers/compose_form_container';
 import NavigationContainer from 'mastodon/features/compose/containers/navigation_container';
+import Announcements from 'mastodon/features/compose/components/announcements';
 import { invitesEnabled, version, repository, source_url } from 'mastodon/initial_state';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
@@ -11,6 +12,7 @@ const ComposePanel = () => (
     <SearchContainer openInRoute />
     <NavigationContainer />
     <ComposeFormContainer />
+    <Announcements />
 
     <div className='flex-spacer' />
 


### PR DESCRIPTION
現在、ユーザー設定の "Enable advanced web interface" のチェックを外しシングルカラムレイアウトにすると、お知らせ欄が表示されません。
これを改善します。

image
before:  [default theme](https://taruntarun.net/media_files/Mastodon/media_attachments/files/000/448/939/original/78d98fa38884f207.png)

after: [default theme](https://taruntarun.net/media_files/Mastodon/media_attachments/files/000/448/940/original/97a7db8a01767c4c.png) /  [light theme](https://taruntarun.net/media_files/Mastodon/media_attachments/files/000/448/941/original/076801a0f5c3e49f.png)
