### PR TITLE
Announcements の名称変更

### DIFF
--- a/app/javascript/mastodon/features/compose/components/mods_announcements.js
+++ b/app/javascript/mastodon/features/compose/components/mods_announcements.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import axios from 'axios';
 import classnames from 'classnames';
 
-class Announcement extends React.PureComponent {
+class ModAnnouncement extends React.PureComponent {
 
   static propTypes = {
     item: ImmutablePropTypes.map,
@@ -15,10 +15,10 @@ class Announcement extends React.PureComponent {
     const { item } = this.props;
 
     const contents = [];
-    contents.push(<div key='body' className='announcements__body'>{item.get('body')}</div>);
+    contents.push(<div key='body' className='mods__announcements__body'>{item.get('body')}</div>);
     if (item.get('icon')) {
       contents.push(
-        <div key='icon' className='announcements__icon'>
+        <div key='icon' className='mods__announcements__icon'>
           <img src={item.get('icon')} alt='' />
         </div>
       );
@@ -27,8 +27,8 @@ class Announcement extends React.PureComponent {
     const href = item.get('href');
 
     const classname = classnames({
-      'announcements__item': true,
-      'announcements__item--clickable': !!href,
+      'mods__announcements__item': true,
+      'mods__announcements__item--clickable': !!href,
     });
 
     if (!href) {
@@ -42,10 +42,10 @@ class Announcement extends React.PureComponent {
 
 }
 
-export default class Announcements extends React.PureComponent {
+export default class ModsAnnouncements extends React.PureComponent {
 
   state = {
-    items: Announcements.cache || Immutable.Map(),
+    items: ModsAnnouncements.cache || Immutable.Map(),
   }
 
   static isCacheControlled = false
@@ -88,15 +88,15 @@ export default class Announcements extends React.PureComponent {
 
     axios.get('/announcements.json', {
       headers: {
-        'If-Modified-Since': !Announcements.isCacheControlled && Announcements.lastDate || '',
+        'If-Modified-Since': !ModsAnnouncements.isCacheControlled && ModsAnnouncements.lastDate || '',
       },
     })
       .then(resp => {
-        Announcements.isCacheControlled = !!resp.headers['cache-control'];
-        Announcements.lastDate = resp.headers['last-modified'];
+        ModsAnnouncements.isCacheControlled = !!resp.headers['cache-control'];
+        ModsAnnouncements.lastDate = resp.headers['last-modified'];
         return resp;
       })
-      .then(resp => this.setState({ items: Announcements.cache = Immutable.fromJS(resp.data) || {} }))
+      .then(resp => this.setState({ items: ModsAnnouncements.cache = Immutable.fromJS(resp.data) || {} }))
       .catch(err => err.response.status !== 304 && console.warn(err))
       .then(this.deleteServiceWorkerCache)
       .then(this.setPolling)
@@ -107,10 +107,10 @@ export default class Announcements extends React.PureComponent {
     const { items } = this.state;
 
     return (
-      <ul className='announcements'>
+      <ul className='mods__announcements'>
         {items.entrySeq().map(([key, item]) =>
           (<li key={key}>
-            <Announcement item={item} />
+            <ModAnnouncement item={item} />
           </li>)
         )}
       </ul>

--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -12,7 +12,7 @@ import Motion from '../ui/util/optional_motion';
 import spring from 'react-motion/lib/spring';
 import SearchResultsContainer from './containers/search_results_container';
 import { changeComposing } from '../../actions/compose';
-import Announcements from './components/announcements';
+import ModsAnnouncements from './components/mods_announcements';
 import { openModal } from 'mastodon/actions/modal';
 import elephantUIPlane from '../../../images/elephant_ui_plane.svg';
 import { mascot } from '../../initial_state';
@@ -127,7 +127,7 @@ class Compose extends React.PureComponent {
           {!isSearchPage && <div className='drawer__inner' onFocus={this.onFocus}>
             <NavigationContainer onClose={this.onBlur} />
             <ComposeFormContainer />
-            <Announcements />
+            <ModsAnnouncements />
             <div className='drawer__inner__mastodon'>
               <img alt='' draggable='false' src={mascot || elephantUIPlane} />
             </div>

--- a/app/javascript/mastodon/features/ui/components/compose_panel.js
+++ b/app/javascript/mastodon/features/ui/components/compose_panel.js
@@ -2,7 +2,7 @@ import React from 'react';
 import SearchContainer from 'mastodon/features/compose/containers/search_container';
 import ComposeFormContainer from 'mastodon/features/compose/containers/compose_form_container';
 import NavigationContainer from 'mastodon/features/compose/containers/navigation_container';
-import Announcements from 'mastodon/features/compose/components/announcements';
+import ModsAnnouncements from 'mastodon/features/compose/components/mods_announcements';
 import LinkFooter from './link_footer';
 
 const ComposePanel = () => (
@@ -10,7 +10,7 @@ const ComposePanel = () => (
     <SearchContainer openInRoute />
     <NavigationContainer />
     <ComposeFormContainer singleColumn />
-    <Announcements />
+    <ModsAnnouncements />
     <LinkFooter withHotkeys />
   </div>
 );

--- a/app/javascript/styles/mods/announcements.scss
+++ b/app/javascript/styles/mods/announcements.scss
@@ -1,4 +1,4 @@
-.announcements__item {
+.mods__announcements__item {
   display: flex;
   padding: 10px;
   margin: 10px;
@@ -13,11 +13,11 @@
   }
 }
 
-.announcements__body {
+.mods__announcements__body {
   flex: 1 1 auto;
 }
 
-.announcements__icon {
+.mods__announcements__icon {
   flex: 0 0 auto;
   height: 40px;
   width: 40px;


### PR DESCRIPTION
upstream にて公式に Announcements 機能が実装される予定です。
今のまま master 追従するとここ独自の Announcements 機能の体裁が崩れると思われます。
上記に関する対応と今後の衝突を避けるためにも独自機能の方の Announcements の名称変更を提案します。

運用上の互換性維持のため announcements.json は名称変更していません。

またこの PR をマージせず他の名称等に変更して独自に作り変えていただいても構いません。

このブランチでの動作確認は取っていませんので事前に確認をお願いします。