### PR TITLE
actionlintはいいぞ

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,19 @@
+name: reviewdog / actionlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  actionlint:
+    name: actionlint with reviewdog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: actionlint
+        uses: reviewdog/action-actionlint@v1.18.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review


### PR DESCRIPTION
GitHub Actionsのworkflowのlinter．しかもこれはreviewdogを使ってエラーをPull Request Commentとして吐いてくれる．
GitHub Actionsやっていくなら必須まである．