### PR TITLE
fix post details page layout is broken

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -167,7 +167,6 @@ module ApplicationHelper
     output << 'system-font' if current_account&.user&.setting_system_font_ui
     output << (current_account&.user&.setting_reduce_motion ? 'reduce-motion' : 'no-reduce-motion')
     output << 'bigger-publish' if current_account&.user&.setting_bigger_publish
-    output << 'wider-column' if (current_account&.user&.setting_advanced_layout && current_account&.user&.setting_wider_column)
     output << WEBUI_STYLES[current_account&.user&.setting_webui_styles]
     output << 'reverse-nav' if current_account&.user&.setting_reverse_nav
     output << 'rtl' if locale_direction == 'rtl'

--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -22,7 +22,7 @@ import { clearHeight } from '../../actions/height_cache';
 import { expandNotifications } from '../../actions/notifications';
 import { fetchServer, fetchServerTranslationLanguages } from '../../actions/server';
 import { expandHomeTimeline } from '../../actions/timelines';
-import initialState, { me, owner, singleUserMode, trendsEnabled, trendsAsLanding } from '../../initial_state';
+import initialState, { me, owner, singleUserMode, trendsEnabled, trendsAsLanding, widerColumn, advancedLayout } from '../../initial_state';
 
 import BundleColumnError from './components/bundle_column_error';
 import Header from './components/header';
@@ -577,7 +577,7 @@ class UI extends PureComponent {
 
     return (
       <HotKeys keyMap={keyMap} handlers={handlers} ref={this.setHotkeysRef} attach={window} focused>
-        <div className={classNames('ui', { 'is-composing': isComposing })} ref={this.setRef} style={{ pointerEvents: dropdownMenuIsOpen ? 'none' : null }}>
+        <div className={classNames('ui', { 'is-composing': isComposing }, { 'wider-column': widerColumn && advancedLayout && !(layout === 'mobile' || layout === 'single-column') })} ref={this.setRef} style={{ pointerEvents: dropdownMenuIsOpen ? 'none' : null }}>
           <Header />
 
           <SwitchingColumnsArea location={location} singleColumn={layout === 'mobile' || layout === 'single-column'}>

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -80,6 +80,7 @@
  * @property {boolean} use_blurhash
  * @property {boolean=} use_pending_items
  * @property {string} version
+ * @property {boolean} wider_column
  */
 
 /**
@@ -108,6 +109,7 @@ export const hasMultiColumnPath = initialPath === '/'
 const getMeta = (prop) => initialState?.meta && initialState.meta[prop];
 
 export const activityApiEnabled = getMeta('activity_api_enabled');
+export const advancedLayout = getMeta('advanced_layout');
 export const autoPlayGif = getMeta('auto_play_gif');
 export const boostModal = getMeta('boost_modal');
 export const deleteModal = getMeta('delete_modal');
@@ -138,6 +140,7 @@ export const unfollowModal = getMeta('unfollow_modal');
 export const useBlurhash = getMeta('use_blurhash');
 export const usePendingItems = getMeta('use_pending_items');
 export const version = getMeta('version');
+export const widerColumn = getMeta('wider_column');
 export const languages = initialState?.languages;
 // @ts-expect-error
 export const statusPageUrl = getMeta('status_page_url');

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -11,7 +11,41 @@ class InitialStateSerializer < ActiveModel::Serializer
   has_one :role, serializer: REST::RoleSerializer
 
   def meta
-    store = {
+    store = server_meta
+
+    if object.current_account
+      store[:me]                = object.current_account.id.to_s
+      store[:unfollow_modal]    = object.current_account.user.setting_unfollow_modal
+      store[:boost_modal]       = object.current_account.user.setting_boost_modal
+      store[:delete_modal]      = object.current_account.user.setting_delete_modal
+      store[:auto_play_gif]     = object.current_account.user.setting_auto_play_gif
+      store[:display_media]     = object.current_account.user.setting_display_media
+      store[:expand_spoilers]   = object.current_account.user.setting_expand_spoilers
+      store[:reduce_motion]     = object.current_account.user.setting_reduce_motion
+      store[:disable_swiping]   = object.current_account.user.setting_disable_swiping
+      store[:advanced_layout]   = object.current_account.user.setting_advanced_layout
+      store[:use_blurhash]      = object.current_account.user.setting_use_blurhash
+      store[:use_pending_items] = object.current_account.user.setting_use_pending_items
+      store[:show_trends]       = Setting.trends && object.current_account.user.setting_trends
+      store[:webui_styles]      = object.current_account.user.setting_webui_styles
+      store[:wider_column]      = object.current_account.user.setting_wider_column
+    else
+      store[:auto_play_gif] = Setting.auto_play_gif
+      store[:display_media] = Setting.display_media
+      store[:reduce_motion] = Setting.reduce_motion
+      store[:use_blurhash]  = Setting.use_blurhash
+    end
+
+    store[:disabled_account_id] = object.disabled_account.id.to_s if object.disabled_account
+    store[:moved_to_account_id] = object.moved_to_account.id.to_s if object.moved_to_account
+
+    store[:owner] = object.owner&.id&.to_s if Rails.configuration.x.single_user_mode
+
+    store
+  end
+
+  def server_meta
+    {
       streaming_api_base_url: Rails.configuration.x.streaming_api_base_url,
       access_token: object.token,
       locale: I18n.locale,
@@ -33,35 +67,6 @@ class InitialStateSerializer < ActiveModel::Serializer
       trends_as_landing_page: Setting.trends_as_landing_page,
       status_page_url: Setting.status_page_url,
     }
-
-    if object.current_account
-      store[:me]                = object.current_account.id.to_s
-      store[:unfollow_modal]    = object.current_account.user.setting_unfollow_modal
-      store[:boost_modal]       = object.current_account.user.setting_boost_modal
-      store[:delete_modal]      = object.current_account.user.setting_delete_modal
-      store[:auto_play_gif]     = object.current_account.user.setting_auto_play_gif
-      store[:display_media]     = object.current_account.user.setting_display_media
-      store[:expand_spoilers]   = object.current_account.user.setting_expand_spoilers
-      store[:reduce_motion]     = object.current_account.user.setting_reduce_motion
-      store[:disable_swiping]   = object.current_account.user.setting_disable_swiping
-      store[:advanced_layout]   = object.current_account.user.setting_advanced_layout
-      store[:use_blurhash]      = object.current_account.user.setting_use_blurhash
-      store[:use_pending_items] = object.current_account.user.setting_use_pending_items
-      store[:show_trends]       = Setting.trends && object.current_account.user.setting_trends
-      store[:webui_styles]      = object.current_account.user.setting_webui_styles
-    else
-      store[:auto_play_gif] = Setting.auto_play_gif
-      store[:display_media] = Setting.display_media
-      store[:reduce_motion] = Setting.reduce_motion
-      store[:use_blurhash]  = Setting.use_blurhash
-    end
-
-    store[:disabled_account_id] = object.disabled_account.id.to_s if object.disabled_account
-    store[:moved_to_account_id] = object.moved_to_account.id.to_s if object.moved_to_account
-
-    store[:owner] = object.owner&.id&.to_s if Rails.configuration.x.single_user_mode
-
-    store
   end
 
   def compose


### PR DESCRIPTION
## これはなに？
以下の設定がすべて有効な状態で投稿詳細画面を開いた際、レイアウトが崩れてしまう問題に対する修正パッチ。
- 上級者向けUIを有効にする
- より幅広なカラムを使用する

本事象は、本家側([mastodon/mastodon](https://github.com/mastodon/mastodon))で pull/25893 が取り込まれた事により、投稿詳細画面へのリンクを直接開いた場合に、上級者向けUIが有効であってもシングルカラムで表示されるように変更されたことに起因するもの。

## 画面サンプル
Before:
![スクリーンショット 2023-07-26 214252](https://github.com/akane-blue/mastodon/assets/19360569/01618fc1-7594-4918-a76c-0475017a461f)

After:
![スクリーンショット 2023-07-26 214539](https://github.com/akane-blue/mastodon/assets/19360569/0bf8d36c-e67d-4462-9363-181c76ad9df1)

## 備考
本件対応に伴い `app/serializers/initial_state_serializer.rb#meta` へコード追加を行いましたが、その際にメソッドの長さが基準を超過し静的チェックにてアラートが上がりコミットが行えなかったため、メソッドの分割を行いました。