### PR TITLE
翻訳ボタンを非表示にする設定項目を追加

### DIFF
--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -4,7 +4,7 @@ import { PureComponent } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
 import classnames from 'classnames';
-import { Link, withRouter } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 import Permalink from './permalink';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
 import ChevronRightIcon from '@/material-icons/400-24px/chevron_right.svg?react';
 import { Icon }  from 'mastodon/components/icon';
 import PollContainer from 'mastodon/containers/poll_container';
-import { autoPlayGif, languages as preloadedLanguages } from 'mastodon/initial_state';
+import { autoPlayGif, languages as preloadedLanguages, hideTranslateButton } from 'mastodon/initial_state';
 
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
 
@@ -246,7 +246,7 @@ class StatusContent extends PureComponent {
     const renderReadMore = this.props.onClick && status.get('collapsed');
     const contentLocale = intl.locale.replace(/[_-].*/, '');
     const targetLanguages = this.props.languages?.get(status.get('language') || 'und');
-    const renderTranslate = this.props.onTranslate && this.context.identity.signedIn && ['public', 'unlisted'].includes(status.get('visibility')) && status.get('search_index').trim().length > 0 && targetLanguages?.includes(contentLocale);
+    const renderTranslate = !hideTranslateButton && this.props.onTranslate && this.context.identity.signedIn && ['public', 'unlisted'].includes(status.get('visibility')) && status.get('search_index').trim().length > 0 && targetLanguages?.includes(contentLocale);
 
     const content = { __html: statusContent ?? getStatusContent(status) };
     const spoilerContent = { __html: status.getIn(['translation', 'spoilerHtml']) || status.get('spoilerHtml') };

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -19,6 +19,7 @@
  * @property {string} display_media
  * @property {string} domain
  * @property {boolean=} expand_spoilers
+ * @property {boolean} hide_translate_button
  * @property {boolean} limited_federation_mode
  * @property {string} locale
  * @property {string | null} mascot
@@ -84,6 +85,7 @@ export const displayMedia = getMeta('display_media');
 export const domain = getMeta('domain');
 export const expandSpoilers = getMeta('expand_spoilers');
 export const forceSingleColumn = !getMeta('advanced_layout');
+export const hideTranslateButton = getMeta('hide_translate_button');
 export const limitedFederationMode = getMeta('limited_federation_mode');
 export const mascot = getMeta('mascot');
 export const me = getMeta('me');

--- a/app/models/concerns/user/has_settings.rb
+++ b/app/models/concerns/user/has_settings.rb
@@ -150,4 +150,8 @@ module User::HasSettings
   def setting_reverse_nav
     settings['web.mod_reverse_nav']
   end
+
+  def setting_hide_translate_button
+    settings['web.hide_translate_button']
+  end
 end

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -36,6 +36,7 @@ class UserSettings
     setting :mod_wider_column, default: false
     setting :mod_webui_styles, default: 'default', in: %w(default compact legacy)
     setting :mod_reverse_nav, default: false
+    setting :hide_translate_button, default: false
   end
 
   namespace :notification_emails do

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -16,21 +16,7 @@ class InitialStateSerializer < ActiveModel::Serializer
     store = default_meta_store
 
     if object.current_account
-      store[:me]                = object.current_account.id.to_s
-      store[:unfollow_modal]    = object_account_user.setting_unfollow_modal
-      store[:boost_modal]       = object_account_user.setting_boost_modal
-      store[:delete_modal]      = object_account_user.setting_delete_modal
-      store[:auto_play_gif]     = object_account_user.setting_auto_play_gif
-      store[:display_media]     = object_account_user.setting_display_media
-      store[:expand_spoilers]   = object_account_user.setting_expand_spoilers
-      store[:reduce_motion]     = object_account_user.setting_reduce_motion
-      store[:disable_swiping]   = object_account_user.setting_disable_swiping
-      store[:advanced_layout]   = object_account_user.setting_advanced_layout
-      store[:use_blurhash]      = object_account_user.setting_use_blurhash
-      store[:use_pending_items] = object_account_user.setting_use_pending_items
-      store[:show_trends]       = Setting.trends && object_account_user.setting_trends
-      store[:webui_styles]      = object_account_user.setting_webui_styles
-      store[:wider_column]      = object_account_user.setting_wider_column
+      store = store.merge(current_account_settings)
     else
       store[:auto_play_gif] = Setting.auto_play_gif
       store[:display_media] = Setting.display_media
@@ -111,6 +97,27 @@ class InitialStateSerializer < ActiveModel::Serializer
       trends_as_landing_page: Setting.trends_as_landing_page,
       trends_enabled: Setting.trends,
       version: instance_presenter.version,
+    }
+  end
+
+  def current_account_settings
+    {
+      me: object.current_account.id.to_s,
+      unfollow_modal: object_account_user.setting_unfollow_modal,
+      boost_modal: object_account_user.setting_boost_modal,
+      delete_modal: object_account_user.setting_delete_modal,
+      auto_play_gif: object_account_user.setting_auto_play_gif,
+      display_media: object_account_user.setting_display_media,
+      expand_spoilers: object_account_user.setting_expand_spoilers,
+      reduce_motion: object_account_user.setting_reduce_motion,
+      disable_swiping: object_account_user.setting_disable_swiping,
+      advanced_layout: object_account_user.setting_advanced_layout,
+      use_blurhash: object_account_user.setting_use_blurhash,
+      use_pending_items: object_account_user.setting_use_pending_items,
+      show_trends: Setting.trends && object_account_user.setting_trends,
+      webui_styles: object_account_user.setting_webui_styles,
+      wider_column: object_account_user.setting_wider_column,
+      hide_translate_button: object_account_user.setting_hide_translate_button,
     }
   end
 

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -108,5 +108,8 @@
     .fields-group
       = ff.input :'web.expand_content_warnings', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_expand_spoilers')
 
+    .fields-group
+      = ff.input :'web.hide_translate_button', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_hide_translate_button')
+
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -222,6 +222,7 @@ en:
         setting_display_media_show_all: Show all
         setting_expand_spoilers: Always expand posts marked with content warnings
         setting_hide_network: Hide your social graph
+        setting_hide_translate_button: Hide translation button
         setting_reduce_motion: Reduce motion in animations
         setting_system_font_ui: Use system's default font
         setting_theme: Site theme

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -222,6 +222,7 @@ ja:
         setting_display_media_show_all: 表示
         setting_expand_spoilers: 閲覧注意としてマークされた投稿を常に展開する
         setting_hide_network: 繋がりを隠す
+        setting_hide_translate_button: 翻訳ボタンを非表示にする
         setting_reduce_motion: アニメーションの動きを減らす
         setting_system_font_ui: システムのデフォルトフォントを使う
         setting_theme: サイトテーマ


### PR DESCRIPTION
# これはなに
- 翻訳ボタンを常に非表示にするオプションを追加します。

## As-Is
- 翻訳機能が有効に設定されている場合に必要に応じて翻訳ボタンが自動で表示される。
- 翻訳ボタンを常に非表示にするオプションはエンドユーザーへ提供されていない。

## To-Be
- 翻訳機能が有効に設定されている場合に必要に応じて翻訳ボタンが自動で表示される。
- エンドユーザー向けに翻訳ボタンを常に非表示にするオプションを提供することにより、エンドユーザーが当該オプションを有効化している場合は翻訳ボタンの表示条件を満たしていても翻訳ボタンが表示されないようになる。

# その他
~~Linterを黙らせるために~~`app/serializers/initial_state_serializer.rb`のリファクタリングを実施しています。(metaメソッド内の処理を別メソッドへ切り出し)
そのため、Upstreamのコードをマージする際に当該箇所がコンフリクトを起こす可能性があります。