### PR TITLE
パーマリンク独自拡張が投稿詳細表示時に壊れていた問題を修正

### DIFF
--- a/app/javascript/mastodon/features/status/components/detailed_status.tsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.tsx
@@ -19,6 +19,7 @@ import type { StatusLike } from 'mastodon/components/hashtag_bar';
 import { getHashtagBarForStatus } from 'mastodon/components/hashtag_bar';
 import { Icon } from 'mastodon/components/icon';
 import { IconLogo } from 'mastodon/components/logo';
+import Permalink from 'mastodon/components/permalink';
 import PictureInPicturePlaceholder from 'mastodon/components/picture_in_picture_placeholder';
 import { VisibilityIcon } from 'mastodon/components/visibility_icon';
 
@@ -311,8 +312,9 @@ export const DetailedStatus: React.FC<{
             />
           </div>
         )}
-        <a
+        <Permalink
           href={status.getIn(['account', 'url'])}
+          to={`/@${status.getIn(['account', 'acct'])}`}
           data-hover-card-account={status.getIn(['account', 'id'])}
           className='detailed-status__display-name'
         >
@@ -326,7 +328,7 @@ export const DetailedStatus: React.FC<{
               <IconLogo />
             </>
           )}
-        </a>
+        </Permalink>
 
         {status.get('spoiler_text').length > 0 && (
           <ContentWarning


### PR DESCRIPTION
上級者向けUIで投稿の詳細表示を行った際、投稿ヘッダー部に表示されているアカウント投稿者のリンクの挙動が想定と異なっていたため、修正を行いました。
修正前：リンクをクリックすると当該アカウントのURLへ遷移する（リモートサーバー上のアカウントページへ遷移する）
修正後：リンクをクリックすると当該アカウントのページへ遷移する（同一サーバー内でのページ遷移 ※サーバーにキャッシュされたアカウント情報を表示）