### PR TITLE
libvips使用時にPNG to JPEG変換処理が正常に動作していない問題を修正

### DIFF
--- a/lib/paperclip/img_converter.rb
+++ b/lib/paperclip/img_converter.rb
@@ -16,13 +16,14 @@ module Paperclip
 
       if opaque?(image)
         basename = File.basename(file.path, File.extname(file.path))
-        dst_name = basename << '.jpg'
+        dst_name = basename << '.jpeg'
 
         dst = Paperclip::TempfileFactory.new.generate(dst_name)
 
         new_vipsimage_from_file(src_path).write_to_file(File.expand_path(dst.path), **save_options)
 
         if @file.size > dst.size
+          attachment.instance.file_file_name = "#{File.basename(attachment.instance.file_file_name, '.*')}.jpeg"
           attachment.instance.file_content_type = 'image/jpeg'
           return dst
         end
@@ -39,7 +40,7 @@ module Paperclip
 
       if opaque == 'true'
         basename = File.basename(file.path, File.extname(file.path))
-        dst_name = basename << '.jpg'
+        dst_name = basename << '.jpeg'
 
         dst = Paperclip::TempfileFactory.new.generate(dst_name)
 
@@ -48,6 +49,7 @@ module Paperclip
                 dst: File.expand_path(dst.path))
 
         if @file.size > dst.size
+          attachment.instance.file_file_name = "#{File.basename(attachment.instance.file_file_name, '.*')}.jpeg"
           attachment.instance.file_content_type = 'image/jpeg'
           return dst
         end


### PR DESCRIPTION
PNG形式の画像について、ファイルサイズを抑えるためにJPEG形式へ変換する処理が導入されているが、この処理がlibvips切り替え後に想定通り動作していなかった。(変換後のJPEG形式ファイルではなく、PNG形式のファイルが採用されていた)
本変更では、当該パターンに該当する場合でも想定通りの動作となるよう修正を行った。